### PR TITLE
Drop CentOS 8 testing, add Ansible 2.17 testing and fix issue installing Smallstep CLI packages > v0.27.2

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,7 +36,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        distro: [centos8, centos9, debian10, debian11, debian12, ubuntu2004, ubuntu2204, ubuntu2404]
+        distro: [centos9, debian10, debian11, debian12, ubuntu2004, ubuntu2204, ubuntu2404]
         experimental: [false]
         molecule_scenario: ["-s default", "-s step_ssh"]
     uses: ./.github/workflows/test.yml

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,6 +4,32 @@ trfore.smallstep Collection Release Notes
 
 .. contents:: Topics
 
+v1.2.0
+======
+
+Release Summary
+---------------
+
+Fix installing Smallstep CLI > 0.27.2, add testing for Ansible 2.17, and remove testing/support for CentOS 8
+
+Breaking Changes / Porting Guide
+--------------------------------
+
+- Remove testing support for CentOS 8 due to EOL.
+
+Bugfixes
+--------
+
+- Pulling the latest smallstep CLI package, due to the GitHub tag not aligning with the package name.
+
+v1.1.2
+======
+
+Release Summary
+---------------
+
+Improve development workflow with format/lint configs and GH workflows
+
 v1.1.1
 ======
 

--- a/changelogs/changelog.yaml
+++ b/changelogs/changelog.yaml
@@ -3,47 +3,66 @@ releases:
   1.0.0:
     changes:
       major_changes:
-      - Consolidated numerous step roles into a single collection.
+        - Consolidated numerous step roles into a single collection.
       release_summary: Initial collection release, deploy a PKI using Smallstep.
     fragments:
-    - release_v1.0.0.yml
+      - release_v1.0.0.yml
     objects:
       role:
-      - description: Install and Initialize Step CA
-        name: step_ca
-        namespace: null
-      - description: Download and add the CA root certificate to trust stores
-        name: step_ca_cert
-        namespace: null
-      - description: Request an x509 certificate from the CA and automatically renew
-          it
-        name: step_cert
-        namespace: null
-      - description: Install Step CLI
-        name: step_cli
-        namespace: null
-      - description: Add provisioners to Step CA
-        name: step_provisioner
-        namespace: null
-    release_date: '2024-04-01'
+        - description: Install and Initialize Step CA
+          name: step_ca
+          namespace: null
+        - description: Download and add the CA root certificate to trust stores
+          name: step_ca_cert
+          namespace: null
+        - description: Request an x509 certificate from the CA and automatically renew
+            it
+          name: step_cert
+          namespace: null
+        - description: Install Step CLI
+          name: step_cli
+          namespace: null
+        - description: Add provisioners to Step CA
+          name: step_provisioner
+          namespace: null
+    release_date: "2024-04-01"
   1.1.0:
     changes:
       major_changes:
-      - Added SSH role for generating SSH certificates.
-      - Added support for CentOS 8-9 and Debian 10-12.
+        - Added SSH role for generating SSH certificates.
+        - Added support for CentOS 8-9 and Debian 10-12.
       release_summary: New feature, request SSH certificates from step CA.
     fragments:
-    - release_v1.1.0.yml
+      - release_v1.1.0.yml
     objects:
       role:
-      - description: Request SSH Certificates from step CA Server
-        name: step_ssh
-        namespace: null
-    release_date: '2024-04-01'
+        - description: Request SSH Certificates from step CA Server
+          name: step_ssh
+          namespace: null
+    release_date: "2024-04-01"
   1.1.1:
     changes:
       release_summary: Adds files to improve development workflow; validates collection
         against step-ca & cli `0.26.1`
     fragments:
-    - release_v1.1.1.yml
-    release_date: '2024-04-25'
+      - release_v1.1.1.yml
+    release_date: "2024-04-25"
+  1.1.2:
+    changes:
+      release_summary: Improve development workflow with format/lint configs and GH
+        workflows
+    fragments:
+      - release_v1.1.2.yml
+    release_date: "2024-05-05"
+  1.2.0:
+    changes:
+      breaking_changes:
+        - Remove testing support for CentOS 8 due to EOL.
+      bugfixes:
+        - Pulling the latest smallstep CLI package, due to the GitHub tag not aligning
+          with the package name.
+      release_summary: Fix installing Smallstep CLI > 0.27.2, add testing for Ansible
+        2.17, and remove testing/support for CentOS 8
+    fragments:
+      - release_v1.2.0.yml
+    release_date: "2024-11-04"

--- a/changelogs/fragments/release_v1.1.2.yml
+++ b/changelogs/fragments/release_v1.1.2.yml
@@ -1,3 +1,4 @@
+release_summary: Improve development workflow with format/lint configs and GH workflows
 trivial:
   - Add ansible-lint config file
   - Style updates to align with new style and lint configurations

--- a/changelogs/fragments/release_v1.2.0.yml
+++ b/changelogs/fragments/release_v1.2.0.yml
@@ -1,0 +1,9 @@
+release_summary: Fix installing Smallstep CLI > 0.27.2, add testing for Ansible 2.17, and remove testing/support for CentOS 8
+breaking_changes:
+  - Remove testing support for CentOS 8 due to EOL.
+bugfixes:
+  - Pulling the latest smallstep CLI package, due to the GitHub tag not aligning with the package name.
+trivial:
+  - Update tox to test Ansible 2.17.
+  - Unpin Ansible python pkgs as upstream repos are pinning and validating 'requests' pkg.
+  - Validate against step-ca and step-cli `0.27.4` to `0.28.0`.

--- a/galaxy.yml
+++ b/galaxy.yml
@@ -1,6 +1,6 @@
 namespace: trfore
 name: smallstep
-version: 1.1.2
+version: 1.2.0
 readme: README.md
 authors:
   - Taylor Fore (https://github.com/trfore/)

--- a/requirements/dev-requirements.txt
+++ b/requirements/dev-requirements.txt
@@ -10,7 +10,6 @@ pre-commit>=3.2.0
 pylint>=3.0.0
 pytest>=7.0.0
 pytest-testinfra>=7.0.0
-requests<2.32.0
 tox>=4.0.0
 tox-ansible>=2.0.0
 yamllint>=1.30.0

--- a/roles/step_ca/meta/main.yml
+++ b/roles/step_ca/meta/main.yml
@@ -10,7 +10,7 @@ galaxy_info:
     - name: Debian
       versions: [buster, bullseye, bookworm]
     - name: EL
-      versions: ["8", "9"]
+      versions: ["9"]
     - name: Ubuntu
       versions: [focal, jammy, noble]
 

--- a/roles/step_ca_cert/meta/main.yml
+++ b/roles/step_ca_cert/meta/main.yml
@@ -10,7 +10,7 @@ galaxy_info:
     - name: Debian
       versions: [buster, bullseye, bookworm]
     - name: EL
-      versions: ["8", "9"]
+      versions: ["9"]
     - name: Ubuntu
       versions: [focal, jammy, noble]
 

--- a/roles/step_cert/meta/main.yml
+++ b/roles/step_cert/meta/main.yml
@@ -10,7 +10,7 @@ galaxy_info:
     - name: Debian
       versions: [buster, bullseye, bookworm]
     - name: EL
-      versions: ["8", "9"]
+      versions: ["9"]
     - name: Ubuntu
       versions: [focal, jammy, noble]
 

--- a/roles/step_cli/defaults/main.yml
+++ b/roles/step_cli/defaults/main.yml
@@ -1,4 +1,5 @@
 ---
 step_cli_checksum: "https://github.com/smallstep/cli/releases/download/v{{ step_cli_version }}/checksums.txt"
-step_cli_pkg_src: "https://github.com/smallstep/cli/releases/download/v{{ step_cli_version }}/step-cli_{{ step_cli_version }}_amd64.{{ __pkg_extension }}"
+step_cli_pkg_name: "{% if step_cli_version > '0.27.2' %}{{ step_cli_version }}-1{% else %}{{ step_cli_version }}{% endif %}"
+step_cli_pkg_src: "https://github.com/smallstep/cli/releases/download/v{{ step_cli_version }}/step-cli_{{ step_cli_pkg_name }}_amd64.{{ __pkg_extension }}"
 step_cli_version: "latest"

--- a/roles/step_cli/meta/main.yml
+++ b/roles/step_cli/meta/main.yml
@@ -9,7 +9,7 @@ galaxy_info:
     - name: Debian
       versions: [buster, bullseye, bookworm]
     - name: EL
-      versions: ["8", "9"]
+      versions: ["9"]
     - name: Ubuntu
       versions: [focal, jammy, noble]
 

--- a/roles/step_provisioner/meta/main.yml
+++ b/roles/step_provisioner/meta/main.yml
@@ -10,7 +10,7 @@ galaxy_info:
     - name: Debian
       versions: [buster, bullseye, bookworm]
     - name: EL
-      versions: ["8", "9"]
+      versions: ["9"]
     - name: Ubuntu
       versions: [focal, jammy, noble]
 

--- a/roles/step_ssh/meta/main.yml
+++ b/roles/step_ssh/meta/main.yml
@@ -10,7 +10,7 @@ galaxy_info:
     - name: Debian
       versions: [buster, bullseye, bookworm]
     - name: EL
-      versions: ["8", "9"]
+      versions: ["9"]
     - name: Ubuntu
       versions: [focal, jammy, noble]
 

--- a/tox.ini
+++ b/tox.ini
@@ -3,9 +3,9 @@ minversion = 4.0.0
 envlist =
     lint
     docs
-    py-ansible{2.15, 2.16}-{default,ssh}
-    py-ansible{2.16}-{default,ssh}-{centos, debian}
-    py-ansible{2.16}-{mult}
+    py-ansible{2.15, 2.16, 2.17}-{default,ssh}
+    py-ansible{2.16, 2.17}-{default,ssh}-{centos, debian}
+    py-ansible{2.17}-{multi}
 
 [testenv]
 description =
@@ -15,10 +15,11 @@ description =
     centos-!default: Run molecule scenario on CentOS (step_ssh)
     debian-!ssh: Run molecule scenario on Debian (default)
     debian-!default: Run molecule scenario on Debian (default)
-    mult: Run molecule scenario to request multiple server certs (Ubuntu)
+    multi: Run molecule scenario to request multiple server certs (Ubuntu)
 deps =
     ansible2.15: ansible-core == 2.15.*
     ansible2.16: ansible-core == 2.16.*
+    ansible2.17: ansible-core == 2.17.*
     docker
     jmespath
     molecule
@@ -28,7 +29,7 @@ deps =
 commands =
     default: molecule {posargs:test -s default}
     ssh: molecule {posargs:test -s step_ssh}
-    mult: molecule {posargs:test -s multiple_certs}
+    multi: molecule {posargs:test -s multiple_certs}
 setenv =
     ANSIBLE_COLLECTIONS_PATH={work_dir}/{env_name}/.ansible/collections/ansible_collections
     MOLECULE_EPHEMERAL_DIRECTORY={work_dir}/{env_name}/.cache/molecule


### PR DESCRIPTION
release_summary: Fix installing Smallstep CLI > 0.27.2, add testing for Ansible 2.17, and remove testing/support for CentOS 8

breaking_changes:
  - Remove testing support for CentOS 8 due to EOL.

bugfixes:
  - Issue #16
 
trivial:
  - Update tox to test Ansible 2.17.
  - Unpin Ansible python pkgs as upstream repos are pinning and validating 'requests' pkg.
  - Validate against step-ca and step-cli `0.27.4` to `0.28.0`.