### PR TITLE
Remove Debian 10 from Test Matrix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,7 +36,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        distro: [centos9, debian10, debian11, debian12, ubuntu2004, ubuntu2204, ubuntu2404]
+        distro: [centos9, debian11, debian12, ubuntu2004, ubuntu2204, ubuntu2404]
         experimental: [false]
         molecule_scenario: ["-s default", "-s step_ssh"]
     uses: ./.github/workflows/test.yml

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -16,6 +16,7 @@ Breaking Changes / Porting Guide
 --------------------------------
 
 - Remove testing support for CentOS 8 due to EOL.
+- Remove testing support for Debian 10 due to EOL.
 
 Bugfixes
 --------

--- a/README.md
+++ b/README.md
@@ -31,9 +31,9 @@ ansible-galaxy collection install trfore.smallstep
 
 ## Tested Platforms
 
-- `ansible-core` 2.14, 2.15 & 2.16
-- CentOS Stream 8 & 9
-- Debian 10, 11 & 12
+- `ansible-core` 2.15, 2.16 & 2.17
+- CentOS Stream 9
+- Debian 11 & 12
 - Ubuntu 20.04, 22.04 & 24.04
 
 ## Example Playbook

--- a/changelogs/changelog.yaml
+++ b/changelogs/changelog.yaml
@@ -58,6 +58,7 @@ releases:
     changes:
       breaking_changes:
         - Remove testing support for CentOS 8 due to EOL.
+        - Remove testing support for Debian 10 due to EOL.
       bugfixes:
         - Pulling the latest smallstep CLI package, due to the GitHub tag not aligning
           with the package name.

--- a/changelogs/fragments/release_v1.2.0.yml
+++ b/changelogs/fragments/release_v1.2.0.yml
@@ -1,6 +1,7 @@
 release_summary: Fix installing Smallstep CLI > 0.27.2, add testing for Ansible 2.17, and remove testing/support for CentOS 8
 breaking_changes:
   - Remove testing support for CentOS 8 due to EOL.
+  - Remove testing support for Debian 10 due to EOL.
 bugfixes:
   - Pulling the latest smallstep CLI package, due to the GitHub tag not aligning with the package name.
 trivial:

--- a/roles/step_ca/meta/main.yml
+++ b/roles/step_ca/meta/main.yml
@@ -8,7 +8,7 @@ galaxy_info:
 
   platforms:
     - name: Debian
-      versions: [buster, bullseye, bookworm]
+      versions: [bullseye, bookworm]
     - name: EL
       versions: ["9"]
     - name: Ubuntu

--- a/roles/step_ca_cert/meta/main.yml
+++ b/roles/step_ca_cert/meta/main.yml
@@ -8,7 +8,7 @@ galaxy_info:
 
   platforms:
     - name: Debian
-      versions: [buster, bullseye, bookworm]
+      versions: [bullseye, bookworm]
     - name: EL
       versions: ["9"]
     - name: Ubuntu

--- a/roles/step_cert/meta/main.yml
+++ b/roles/step_cert/meta/main.yml
@@ -8,7 +8,7 @@ galaxy_info:
 
   platforms:
     - name: Debian
-      versions: [buster, bullseye, bookworm]
+      versions: [bullseye, bookworm]
     - name: EL
       versions: ["9"]
     - name: Ubuntu

--- a/roles/step_cli/meta/main.yml
+++ b/roles/step_cli/meta/main.yml
@@ -7,7 +7,7 @@ galaxy_info:
 
   platforms:
     - name: Debian
-      versions: [buster, bullseye, bookworm]
+      versions: [bullseye, bookworm]
     - name: EL
       versions: ["9"]
     - name: Ubuntu

--- a/roles/step_provisioner/meta/main.yml
+++ b/roles/step_provisioner/meta/main.yml
@@ -8,7 +8,7 @@ galaxy_info:
 
   platforms:
     - name: Debian
-      versions: [buster, bullseye, bookworm]
+      versions: [bullseye, bookworm]
     - name: EL
       versions: ["9"]
     - name: Ubuntu

--- a/roles/step_ssh/meta/main.yml
+++ b/roles/step_ssh/meta/main.yml
@@ -8,7 +8,7 @@ galaxy_info:
 
   platforms:
     - name: Debian
-      versions: [buster, bullseye, bookworm]
+      versions: [bullseye, bookworm]
     - name: EL
       versions: ["9"]
     - name: Ubuntu


### PR DESCRIPTION
breaking_changes:
- Remove testing support for Debian 10 due to EOL.