### PR TITLE
Add suport for alternative hostname of CA

### DIFF
--- a/roles/step_ca/tasks/initialize.yml
+++ b/roles/step_ca/tasks/initialize.yml
@@ -62,6 +62,7 @@
     --name={{ step_ca_name }}
     --dns={{ ansible_fqdn }}
     --dns={{ ansible_default_ipv4.address }}
+    {% if step_ca_alt_fqdn is defined %}--dns {{ step_ca_alt_fqdn }}{% endif %}
     --address={{ step_ca_address }}
     --provisioner={{ step_ca_name }}
     --password-file={{ ca_password_file.dest }}


### PR DESCRIPTION
## Description
Added a variable step_ca_alt_fqdn to register step ca to an alias additionally to the ansible_fqdn and ipv4 address.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x ] This change requires a documentation update
