### PR TITLE
fix: quote CA name to handle spaces in step_ca init

### DIFF
--- a/roles/step_ca/tasks/initialize.yml
+++ b/roles/step_ca/tasks/initialize.yml
@@ -59,11 +59,11 @@
     {% if step_ca_root_key is defined %}--key {{ step_ca_root_key }}{% endif %}
     {% if step_ca_root_key_password is defined %}--key-password-file {{ step_ca_root_key_password }}{% endif %}
     {% if step_ca_ssh_mgmt is true %}--ssh{% endif %}
-    --name={{ step_ca_name }}
+    --name={{ step_ca_name | quote }}
     --dns={{ ansible_fqdn }}
     --dns={{ ansible_default_ipv4.address }}
     --address={{ step_ca_address }}
-    --provisioner={{ step_ca_name }}
+    --provisioner={{ step_ca_name | quote }}
     --password-file={{ ca_password_file.dest }}
     --provisioner-password-file={{ provisioner_password_file.dest }}
 


### PR DESCRIPTION
## Description

This change fixes CA names from being cutoff when initializing step_ca.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

When initializing step-ca with a step_ca_name that contains spaces, the CA name in the generated certificates are cutoff at the first space. By quoting, we now see the expected CA name.

### Test Configuration

N/A

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [N/A] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
