### PR TITLE
Update certs.yml - fixed not-after

### DIFF
--- a/roles/step_cert/tasks/certs.yml
+++ b/roles/step_cert/tasks/certs.yml
@@ -26,7 +26,7 @@
     {% if item.token is defined %}--token {{ item.token }}{% endif %}
     {% if item.san_0 is defined %}--san {{ item.san_0 }}{% endif %}
     {% if item.san_1 is defined %}--san {{ item.san_1 }}{% endif %}
-    {% if item.not_after is defined %}--san {{ item.not_after }}{% endif %}
+    {% if item.not_after is defined %}--not-after {{ item.not_after }}{% endif %}
     {{ item.subject }}
     {{ item.path }}{{ item.name }}.crt
     {{ item.path }}{{ item.name }}.key


### PR DESCRIPTION
The certificate request --not-after argument was set to --san

## Description

This pull request fixes a bug in the certificate generation task where the `--not-after` argument was incorrectly passed as `--san`.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

### Test Configuration

```sh
# Please provide example playbook or CLI command
- name: Request x509 Certificate
      role: trfore.smallstep.step_cert
      vars:
        step_cert_list:
          - name: "{{ hostname }}.{{ domain_suffix }}"
            subject: "{{ hostname }}.{{ domain_suffix }}"
            path: "/etc/step/certs/"
            san_0: "{{ hostvars[hostname].ansible_host }}"
            not_after: "2160h"  # 90 days
            provisioner: "acme"
```

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
