### PR TITLE
Update main.yml - Added missing x509_max_dur variable

### DIFF
--- a/roles/step_provisioner/tasks/main.yml
+++ b/roles/step_provisioner/tasks/main.yml
@@ -35,6 +35,7 @@
     {% if item.ssh is true %}--ssh{% endif %}
     {% if item.renewal_after_expiry is true %}--allow-renewal-after-expiry{% endif %}
     {% if item.x509_default_dur is defined %}--x509-default-dur {{ item.x509_default_dur }}{% endif %}
+    {% if item.x509_max_dur is defined %}--x509-max-dur {{ item.x509_max_dur }}{% endif %}
     {% if item.client_id is defined %}--client-id {{ item.client_id }}{% endif %}
     {% if item.client_secret is defined %}--client-secret {{ item.client_secret }}{% endif %}
     {% if item.config_endpoint is defined %}--configuration-endpoint {{ item.config_endpoint }}{% endif %}


### PR DESCRIPTION
The "x509_max_dur" variable is documented, but had no effect. So added the missing item for in-line var --x509-max-dur.

## Description

This pull request fixes an issue where the `x509_max_dur` variable was documented but had no effect during execution. The variable was not being passed to the CLI, so the `--x509-max-dur` flag was never set.

The following change was made:
- Added missing Jinja line to pass `x509_max_dur` as an inline CLI argument using `--x509-max-dur {{ item.x509_max_dur }}` when the variable is defined.

This ensures the configured maximum X.509 certificate duration is properly applied when creating provisioners.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

### Test Configuration

```sh
# Please provide example playbook or CLI command
- name: Add Provisioner to Step CA
      role: trfore.smallstep.step_provisioner
      vars:
        step_provisioner:
          - name: acme
            type: acme
            renewal_after_expiry: true
            x509_default_dur: "2160h"  # 90 days
            x509_max_dur: "9552h"    # 398 days
```

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
