### PR TITLE
ci: add sanity test and rm testing on EOL ansible 2.16

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -53,14 +53,15 @@ tox run-parallel
 
 ```sh
 # use a different docker image
-MOLECULE_IMAGE='trfore/docker-debian12-systemd' tox -e py-ansible2.17-default  run
+MOLECULE_IMAGE='trfore/docker-debian12-systemd' tox -e py3.11-ansible2.17-default run
 
 # test a specific version of Smallstep CA or CLI
-STEP_CA_VERSION='0.28.4' STEP_CLI_VERSION='0.28.7' tox -e py-ansible2.17-default  run
-STEP_CA_VERSION='0.28.4' STEP_CLI_VERSION='0.28.7' tox -e py-ansible2.17-ssh  run
+STEP_CA_VERSION='0.28.4' STEP_CLI_VERSION='0.28.7' tox -e py3.11-ansible2.17-default run
+STEP_CA_VERSION='0.28.4' STEP_CLI_VERSION='0.28.7' tox -e py3.11-ansible2.17-ssh run
 
 # highly recommended for parallel runs to avoid API rate limit
 STEP_CA_VERSION='0.28.4' STEP_CLI_VERSION='0.28.7' tox run-parallel
+STEP_CA_VERSION='0.28.4' STEP_CLI_VERSION='0.28.7' tox -f py3.11 run-parallel
 ```
 
 - For iterative development and testing, the tox molecule environments are written to accept `molecule` arguments. This allows for codebase changes to be tested as you write across multiple distros and versions of `ansible-core`.
@@ -71,11 +72,11 @@ tox -e py-ansible2.17-default  run -- converge -s default
 
 # molecule test w/o destroying the container
 # ex: tox -e TOX_ENV_NAME  run -- test -s MOLECULE_SCENARIO_NAME --destroy=never
-STEP_CA_VERSION='0.28.4' STEP_CLI_VERSION='0.28.7' tox -e py-ansible2.17-default  run -- test -s default --destroy=never
-STEP_CA_VERSION='0.28.4' STEP_CLI_VERSION='0.28.7' tox -e py-ansible2.17-ssh  run -- test -s step_ssh --destroy=never
+STEP_CA_VERSION='0.28.4' STEP_CLI_VERSION='0.28.7' tox -e py-ansible2.17-default run -- test -s default --destroy=never
+STEP_CA_VERSION='0.28.4' STEP_CLI_VERSION='0.28.7' tox -e py-ansible2.17-ssh run -- test -s step_ssh --destroy=never
 
 # exec into the container via tox
-tox -e py-ansible2.17-default  run -- login -s default
+tox -e py-ansible2.17-default run -- login -s default
 # exec into the container
 docker exec -it py-ansible2.17-default  bash
 

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ ansible-galaxy collection install trfore.smallstep
 
 ## Tested Platforms
 
-- `ansible-core` 2.16, 2.17 & 2.18
+- `ansible-core` 2.17 & 2.18
 - CentOS Stream 9
 - Debian 11 & 12
 - Ubuntu 22.04 & 24.04

--- a/tox.ini
+++ b/tox.ini
@@ -3,10 +3,10 @@ minversion = 4.0.0
 envlist =
     lint
     docs
-    py-ansible{2.16}-{default}
-    py-ansible{2.17}-{default,ssh}
+    sanity
+    py3.11-ansible{2.17}-{default,ssh}
+    py3.11-ansible{2.18}-{default, ssh, multi}
     py3.11-ansible{2.18}-{default}-{centos, debian}
-    py3.11-ansible{2.18}-{default,ssh,multi}
 
 [testenv]
 description =
@@ -14,7 +14,6 @@ description =
     ssh: Extends default scenario, testing SSH certificate creation
     multi: Test requesting multiple server certs for a single server
 deps =
-    ansible2.16: ansible-core == 2.16.*
     ansible2.17: ansible-core == 2.17.*
     ansible2.18: ansible-core == 2.18.*
     -r ./requirements/dev-requirements.txt
@@ -66,4 +65,17 @@ deps =
 commands =
     pre-commit run {posargs:--all --show-diff-on-failure}
 setenv =
+    TOX_ENVNAME={env_name}
+
+[testenv:sanity]
+description = Run Ansible sanity testing (py 3.11 and ansible-core 2.18)
+deps =
+    tox-ansible
+commands =
+    tox -e sanity-py3.11-2.18 --ansible --conf tox-ansible.ini
+setenv =
+    ANSIBLE_COLLECTIONS_PATH={work_dir}/{env_name}/.ansible/collections/ansible_collections
+    ANSIBLE_ROLES_PATH={work_dir}/{env_name}/.ansible/roles
+    DOCS_PATH={env_dir}/tmp
+    PY_COLORS=1
     TOX_ENVNAME={env_name}


### PR DESCRIPTION
- resolves #57
- removes ansible-core 2.16 from testing matrix as it is EOL
- bumps to py3.11 for testing as its supported across 2.17-2.19