### PR TITLE
fix: lower var priority to allow def in inventory file, fixes #74

### DIFF
--- a/roles/step_ca_cert/defaults/main.yml
+++ b/roles/step_ca_cert/defaults/main.yml
@@ -1,4 +1,6 @@
 ---
-step_ca_path: /etc/step-ca/ # noqa: var-naming[no-role-prefix]
 step_ca_cert_firefox: false
 step_ca_cert_java: false
+step_ca_fingerprint: "" # noqa: var-naming[no-role-prefix]
+step_ca_path: /etc/step-ca/ # noqa: var-naming[no-role-prefix]
+step_ca_url: "" # noqa: var-naming[no-role-prefix]

--- a/roles/step_ca_cert/vars/main.yml
+++ b/roles/step_ca_cert/vars/main.yml
@@ -1,3 +1,1 @@
 ---
-step_ca_fingerprint: "" # noqa: var-naming[no-role-prefix]
-step_ca_url: "" # noqa: var-naming[no-role-prefix]


### PR DESCRIPTION
## Description
Lower the priority of sensitive vars that are required but a default of `null`, this allows for required var checks during a play.

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Local Tox and GH worker
